### PR TITLE
Ignore swap files and run command on start

### DIFF
--- a/gosphinxbuild.go
+++ b/gosphinxbuild.go
@@ -99,9 +99,21 @@ func Watch(path string, cmd string) {
 	watched := walkAndWatch(path, watcher)
 	log.Printf("Watching %d directories\n", watched)
 
+	// Run the command on initial run
+	buildChan <- true
 	for {
 		e := <-watcher.Event
-		log.Printf("Event: %v\n", e)
+
+		// Ignore swap files
+		switch {
+			case strings.HasSuffix(e.Name, ".swp"):
+				continue
+			case strings.HasSuffix(e.Name, "~"):
+				continue
+		}
+
+		log.Printf("Event--: %v\n", e)
+
 		if e.IsCreate() && e.Name != "" {
 			// See if a new directory was created that needs watching
 			fi, err := os.Stat(e.Name)

--- a/gosphinxbuild.go
+++ b/gosphinxbuild.go
@@ -112,7 +112,7 @@ func Watch(path string, cmd string) {
 				continue
 		}
 
-		log.Printf("Event--: %v\n", e)
+		log.Printf("Event: %v\n", e)
 
 		if e.IsCreate() && e.Name != "" {
 			// See if a new directory was created that needs watching


### PR DESCRIPTION
For docs it might not make sense to run the command on start or it might not matter.  Maybe this should be a command line option?

For my use I want it to run a webserver and then reload it when files change so it's useful for it to run the command initially.

Also I made it ignore files that end in ~ or .swp so editing things in vim doesn't cause tons of reloads.
